### PR TITLE
explicitly converting to character for map_chr calls

### DIFF
--- a/R/analytics_query.R
+++ b/R/analytics_query.R
@@ -62,10 +62,10 @@ get_analytic_types <- function(analytic_id, flight_id, efoqa_connection){
     return("UNKNOWN")
   }
 
-  keys <- purrr::map_chr(metadata_values, function(x) x$key )
+  keys <- purrr::map_chr(metadata_values, function(x) as.character( x$key ) )
 
   analytic_type_entries <- metadata_values[keys == "DataType"]
-  analytic_types <- purrr::map_chr( analytic_type_entries, function( x ) x$value )
+  analytic_types <- purrr::map_chr( analytic_type_entries, function( x ) as.character( x$value ) )
 
   return(analytic_types)
 }
@@ -74,7 +74,7 @@ get_analytic_name <- function(analytic_id, flight_id, efoqa_connection){
 
   details <- get_analytic_details(analytic_id, flight_id, efoqa_connection)
 
-  return(details$name)
+  return( as.character( details$name ) )
 
 }
 
@@ -93,7 +93,9 @@ remove_nas_and_convert_type <- function( raw_values_list, force_type_string = FA
 
 
   if( output_type == "String" ){
-    processed_values <- purrr::map_chr( raw_values_list$values, function( x ) ifelse( is.null( x ), NA, x ) )
+    processed_values <- purrr::map_chr( raw_values_list$values, function( x ) ifelse( is.null( x ),
+                                                                                      NA,
+                                                                                      as.character( x ) ) )
   }else{
     processed_values <- purrr::map_dbl( raw_values_list$values, function( x ) ifelse( is.null( x ), NA, x ) )
   }
@@ -107,7 +109,7 @@ convert_analytics_query_to_dataframe <- function( analytics_content_list, flight
 
   analytics_results <- analytics_content_list$results
 
-  analytics_ids <- purrr::map_chr( analytics_results, function(x) x$analyticId )
+  analytics_ids <- purrr::map_chr( analytics_results, function(x) as.character( x$analyticId ) )
   analytics_names <- purrr::map_chr( analytics_ids, get_analytic_name, flight_id, efoqa_connection )
 
   if( coerce_types ){

--- a/R/database_modify.R
+++ b/R/database_modify.R
@@ -127,7 +127,7 @@ delete_from_query <- function( data_source_id, query_list,
     schema_map <- query_list$select$fieldId
     names(schema_map) <- names(target_records)
   }else{
-    schema_map <- purrr::map_chr( query_list$select, ~.$fieldId )
+    schema_map <- purrr::map_chr( query_list$select, ~ as.character( .$fieldId ) )
     names(schema_map) <- names(target_records)
   }
 

--- a/R/database_query.R
+++ b/R/database_query.R
@@ -12,7 +12,7 @@ create_data_frame_from_row <- function(row_of_data, field_names){
 ems_api_response_to_dataframe <- function(ems_api_response){
 
   #I would like to use the tidyr rectangle functions here, but since everything is unnamed I am doing it by hand
-  field_names <- purrr::map_chr(ems_api_response$header, function(x) x$name)
+  field_names <- purrr::map_chr(ems_api_response$header, function(x) as.character( x$name ) )
   results_data_frame <- purrr::map_dfr(ems_api_response$rows, function(x) create_data_frame_from_row(x, field_names))
 
   cleaned_data_frame <- janitor::clean_names(results_data_frame)

--- a/R/logical_parameters.R
+++ b/R/logical_parameters.R
@@ -29,7 +29,7 @@ gather_logical_items_recursively <- function( group_id, efoqa_connection, target
 
   #then process the sub-groups
   groups <- content$groups
-  group_ids <- purrr::map_chr(groups, function(group) group$id)
+  group_ids <- purrr::map_chr(groups, function(group) as.character( group$id ) )
   sub_logical_parameters <- purrr::map_dfr(group_ids, gather_logical_items_recursively, efoqa_connection, target_category)
 
   all_logical_parameters <- dplyr::bind_rows(logical_parameters, sub_logical_parameters)


### PR DESCRIPTION
purrr is deprecating auto-conversion to character in map_chr so switching these to be explicit as.character calls.